### PR TITLE
Added no softban code for SM and USUM

### DIFF
--- a/db/0004000000164800.txt
+++ b/db/0004000000164800.txt
@@ -1,4 +1,5 @@
-
+[No Softban v1.2 (restart to turn off)]
+2045DD70 00000001
 
 [Max Money v1.0]
 D3000000 30000000

--- a/db/0004000000175E00.txt
+++ b/db/0004000000175E00.txt
@@ -1,4 +1,5 @@
-
+[No Softban v1.2 (restart to turn off)]
+2045DD70 00000001
 
 [Raises the all Status of a Pokemon by 6 stage(Fix) v1.0]
 D3000000 00000000

--- a/db/00040000001B5000.txt
+++ b/db/00040000001B5000.txt
@@ -1,4 +1,5 @@
-
+[No Softban v1.1 (restart to turn off)]
+204790A8 00000001
 
 [100%Catch(Gateshark2NTR only)]
 00666FDC E5D00008

--- a/db/00040000001B5100.txt
+++ b/db/00040000001B5100.txt
@@ -1,4 +1,5 @@
-
+[No Softban v1.1 (restart to turn off)]
+204790A8 00000001
 
 [100%Catch(Gateshark2NTR only)]
 00666FDC E5D00008


### PR DESCRIPTION
## Changes

This pull request adds codes which disable the softban that occurs when two people get disconnected while trading online in Gen 7 Pokemon games.  Restarting the game is required to disable the code.

## Games affected
- Pokemon Sun v1.2
- Pokemon Moon v1.2
- Pokemon Ultra Sun v1.1
- Pokemon Ultra Moon v1.1