### PR TITLE
Added USUM codes

### DIFF
--- a/db/00040000001B5000.txt
+++ b/db/00040000001B5000.txt
@@ -1,5 +1,20 @@
 
 
+[No Softban v1.2]
+004790AC E3A04001
+
+[Infinite Island Scans v1.2]
+00455674 E2400000
+
+[QR Scan is 100 Points v1.2]
+0045559C E3510000
+
+[Always UB Wormhole v1.2]
+002DD36C E3A01000
+
+[Always Rainbow Pelago Beans v1.2]
+0044DEBC E3A0600E
+
 [No Softban v1.1 (restart to turn off)]
 204790A8 00000001
 

--- a/db/00040000001B5100.txt
+++ b/db/00040000001B5100.txt
@@ -1,5 +1,20 @@
 
 
+[No Softban v1.2]
+004790B0 E3A04001
+
+[Infinite Island Scans v1.2]
+00455678 E2400000
+
+[QR Scan is 100 Points v1.2]
+004555A0 E3510000
+
+[Always UB Wormhole v1.2]
+002DD36C E3A01000
+
+[Always Rainbow Pelago Beans v1.2]
+0044DEC0 E3A0600E
+
 [No Softban v1.1 (restart to turn off)]
 204790A8 00000001
 


### PR DESCRIPTION
## Description

This pull request adds new codes for the following games:
- Ultra Sun (00040000001B5000)
- Ultra Moon (00040000001B5100)

### New codes:
- No Softban v1.2
- Infinite Island Scans v1.2
- QR Scan is 100 Points v1.2
- Always UB Wormhole v1.2
- Always Rainbow Pelago Beans v1.2

### Notes:
- All codes only work for v1.2 of the games
- The `Infinite Island Scans` code requires 100 points to use, but will never deplete the points
- The `No Softban` code refers to not getting softbanned in Festival Plaza